### PR TITLE
Use correct option identifier in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,6 @@ sonarQubeUnitReporter: {
       outputFile: 'reports/ut_report.xml',
       overrideTestDescription: true,
       testPath: './test',
-      testNamePattern: '.spec.js'
+      testFilePattern: '.spec.js'
 },
 ```


### PR DESCRIPTION
The option is called `testFilePattern` not `testNamePattern`