### PR TITLE
fix PC path style with one backslash in the path, add testPaths instead of testPath for multiple test file locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Issue: https://github.com/karma-runner/karma-junit-reporter/issues/81
 
 Motivation
 http://docs.sonarqube.org/display/PLUG/Generic+Test+Coverage
-http://docs.sonarqube.org/display/PLUG/JavaScript+Unit+Tests+Execution+Reports+Import
 
 Available on npmjs.org
 https://www.npmjs.com/package/karma-sonarqube-unit-reporter
@@ -112,7 +111,7 @@ sonarQubeUnitReporter: {
       sonarQubeVersion: 'LATEST',
       outputFile: 'reports/ut_report.xml',
       overrideTestDescription: true,
-      testPath: './test',
+      testPaths: ['./test', './moreTests'],
       testFilePattern: '.spec.js',
       useBrowserName: false
 },

--- a/index.js
+++ b/index.js
@@ -196,8 +196,9 @@ var SonarQubeUnitReporter = function (baseReporterDecorator, config, logger, hel
   // look for jasmine test files in the specified path
   var overrideTestDescription = reporterConfig.overrideTestDescription || false
   var testPath = reporterConfig.testPath || './'
+  var testPaths = reporterConfig.testPaths || [testPath]
   var testFilePattern = reporterConfig.testFilePattern || '(.spec.ts|.spec.js)'
-  var filesForDescriptions = fileUtil.getFilesForDescriptions(testPath, testFilePattern)
+  var filesForDescriptions = fileUtil.getFilesForDescriptions(testPaths, testFilePattern)
 
   function defaultFilenameFormatter (nextPath, result) {
     return filesForDescriptions[nextPath]

--- a/src/file-util.js
+++ b/src/file-util.js
@@ -21,7 +21,7 @@ function getFilesForDescriptions (startPath, filter) {
           var descriptionEnd = fileText.indexOf(delimeter, position + 10) + 1
           var describe = fileText.substring(position + 10, descriptionEnd - 1)
           describe = describe.replace(/\\\\/g, '/')
-          item = item.replace(/\\\\/g, '/')
+          item = item.replace(/\\\\/g, '/').replace(/\\/g, '/')
           ret[describe] = item
           position = 0
           fileText = fileText.substring(descriptionEnd)

--- a/src/file-util.js
+++ b/src/file-util.js
@@ -5,10 +5,13 @@ module.exports = {
   getFilesForDescriptions: getFilesForDescriptions
 }
 
-function getFilesForDescriptions (startPath, filter) {
+function getFilesForDescriptions (startPaths, filter) {
   var ret = {}
-  var files = findFilesInDir(startPath, filter)
-  files.forEach(findDescriptionInFile)
+
+  startPaths.forEach(function (startPathItem) {
+    var files = findFilesInDir(startPathItem, filter)
+    files.forEach(findDescriptionInFile)
+  })
 
   function findDescriptionInFile (item, index) {
     try {

--- a/test/spec/file-util.spec.js
+++ b/test/spec/file-util.spec.js
@@ -1,34 +1,33 @@
-var path = require('path')
 
 describe('create description - file name map from test sources', function () {
   var fileUtil = require('../../src/file-util.js')
 
   it('one test file, one description', function () {
     var filesForDescriptions = fileUtil.getFilesForDescriptions('test/resources/one_file_one_description', '.spec.js')
-    var expectedPath = path.join('test', 'resources', 'one_file_one_description', 'test.spec.js')
+    var expectedPath = 'test/resources/one_file_one_description/test.spec.js'
     var expected = {'test description': expectedPath}
     expect(filesForDescriptions).toEqual(expected)
   })
 
   it('multiple test files, one description', function () {
     var filesForDescriptions = fileUtil.getFilesForDescriptions('test/resources/multiple_files_one_description', '.spec.js')
-    var firstExpectedPath = path.join('test', 'resources', 'multiple_files_one_description', 'first_test.spec.js')
-    var secondExpectedPath = path.join('test', 'resources', 'multiple_files_one_description', 'second_test.spec.js')
+    var firstExpectedPath = 'test/resources/multiple_files_one_description/first_test.spec.js'
+    var secondExpectedPath = 'test/resources/multiple_files_one_description/second_test.spec.js'
     var expected = {'first test description': firstExpectedPath, 'second test description': secondExpectedPath}
     expect(filesForDescriptions).toEqual(expected)
   })
 
   it('one test file, multiple descriptions', function () {
     var filesForDescriptions = fileUtil.getFilesForDescriptions('test/resources/one_file_multiple_descriptions', '.spec.js')
-    var expectedPath = path.join('test', 'resources', 'one_file_multiple_descriptions', 'test.spec.js')
+    var expectedPath = 'test/resources/one_file_multiple_descriptions/test.spec.js'
     var expected = {'test description': expectedPath, 'another test description': expectedPath}
     expect(filesForDescriptions).toEqual(expected)
   })
 
   it('mutliple test files, multiple descriptions', function () {
     var filesForDescriptions = fileUtil.getFilesForDescriptions('test/resources/multiple_files_multiple_descriptions', '.spec.js')
-    var firstExpectedPath = path.join('test', 'resources', 'multiple_files_multiple_descriptions', 'first_test.spec.js')
-    var secondExpectedPath = path.join('test', 'resources', 'multiple_files_multiple_descriptions', 'second_test.spec.js')
+    var firstExpectedPath = 'test/resources/multiple_files_multiple_descriptions/first_test.spec.js'
+    var secondExpectedPath = 'test/resources/multiple_files_multiple_descriptions/second_test.spec.js'
     var expected = {
       'first test first description': firstExpectedPath,
       'first test second description': firstExpectedPath,

--- a/test/spec/file-util.spec.js
+++ b/test/spec/file-util.spec.js
@@ -3,14 +3,14 @@ describe('create description - file name map from test sources', function () {
   var fileUtil = require('../../src/file-util.js')
 
   it('one test file, one description', function () {
-    var filesForDescriptions = fileUtil.getFilesForDescriptions('test/resources/one_file_one_description', '.spec.js')
+    var filesForDescriptions = fileUtil.getFilesForDescriptions(['test/resources/one_file_one_description'], '.spec.js')
     var expectedPath = 'test/resources/one_file_one_description/test.spec.js'
     var expected = {'test description': expectedPath}
     expect(filesForDescriptions).toEqual(expected)
   })
 
   it('multiple test files, one description', function () {
-    var filesForDescriptions = fileUtil.getFilesForDescriptions('test/resources/multiple_files_one_description', '.spec.js')
+    var filesForDescriptions = fileUtil.getFilesForDescriptions(['test/resources/multiple_files_one_description'], '.spec.js')
     var firstExpectedPath = 'test/resources/multiple_files_one_description/first_test.spec.js'
     var secondExpectedPath = 'test/resources/multiple_files_one_description/second_test.spec.js'
     var expected = {'first test description': firstExpectedPath, 'second test description': secondExpectedPath}
@@ -18,14 +18,14 @@ describe('create description - file name map from test sources', function () {
   })
 
   it('one test file, multiple descriptions', function () {
-    var filesForDescriptions = fileUtil.getFilesForDescriptions('test/resources/one_file_multiple_descriptions', '.spec.js')
+    var filesForDescriptions = fileUtil.getFilesForDescriptions(['test/resources/one_file_multiple_descriptions'], '.spec.js')
     var expectedPath = 'test/resources/one_file_multiple_descriptions/test.spec.js'
     var expected = {'test description': expectedPath, 'another test description': expectedPath}
     expect(filesForDescriptions).toEqual(expected)
   })
 
   it('mutliple test files, multiple descriptions', function () {
-    var filesForDescriptions = fileUtil.getFilesForDescriptions('test/resources/multiple_files_multiple_descriptions', '.spec.js')
+    var filesForDescriptions = fileUtil.getFilesForDescriptions(['test/resources/multiple_files_multiple_descriptions'], '.spec.js')
     var firstExpectedPath = 'test/resources/multiple_files_multiple_descriptions/first_test.spec.js'
     var secondExpectedPath = 'test/resources/multiple_files_multiple_descriptions/second_test.spec.js'
     var expected = {
@@ -33,6 +33,22 @@ describe('create description - file name map from test sources', function () {
       'first test second description': firstExpectedPath,
       'second test first description': secondExpectedPath,
       'second test second description': secondExpectedPath
+    }
+    expect(filesForDescriptions).toEqual(expected)
+  })
+
+  it('two folders, two test files', function () {
+    var filesForDescriptions = fileUtil.getFilesForDescriptions([
+      'test/resources/one_file_one_description',
+      'test/resources/multiple_files_one_description'
+    ], '.spec.js')
+    var firstExpectedPath = 'test/resources/one_file_one_description/test.spec.js'
+    var secondExpectedPath = 'test/resources/multiple_files_one_description/first_test.spec.js'
+    var thirdExpectedPath = 'test/resources/multiple_files_one_description/second_test.spec.js'
+    var expected = {
+      'test description': firstExpectedPath,
+      'first test description': secondExpectedPath,
+      'second test description': thirdExpectedPath
     }
     expect(filesForDescriptions).toEqual(expected)
   })


### PR DESCRIPTION
When you run it on PC the path of the file has just single \\, so backslashes stays in the path non-replaced and, as the result, sonarqube's GenericCoverageSensor can't find any matching files because he's looking for normal slashes (/) in the path.
The second commit is to change testPath to testPaths, so you can specify more than one location for your test files.