### PR TITLE
testPaths is not relative to basePath, unlike outputFile

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,7 +198,13 @@ var SonarQubeUnitReporter = function (baseReporterDecorator, config, logger, hel
   var testPath = reporterConfig.testPath || './'
   var testPaths = reporterConfig.testPaths || [testPath]
   var testFilePattern = reporterConfig.testFilePattern || '(.spec.ts|.spec.js)'
-  var filesForDescriptions = fileUtil.getFilesForDescriptions(testPaths, testFilePattern)
+  var filesForDescriptions
+
+  if (reporterConfig.basePathGlob) {
+    filesForDescriptions = fileUtil.globFilesForDescriptions(reporterConfig.basePathGlob, config.basePath)
+  } else {
+    filesForDescriptions = fileUtil.getFilesForDescriptions(testPaths, testFilePattern)
+  }
 
   function defaultFilenameFormatter (nextPath, result) {
     return filesForDescriptions[nextPath]

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-config-standard": "^4.1.0",
     "eslint-plugin-jasmine": "2.2.0",
     "eslint-plugin-standard": "^1.3.1",
+    "glob": "^7.1.3",
     "grunt": "^0.4.1",
     "grunt-bump": "^0.5.0",
     "grunt-conventional-changelog": "^4.1.0",

--- a/test/spec/file-util.spec.js
+++ b/test/spec/file-util.spec.js
@@ -52,4 +52,23 @@ describe('create description - file name map from test sources', function () {
     }
     expect(filesForDescriptions).toEqual(expected)
   })
+
+  it('globs many files', function () {
+    var filesForDescriptions = fileUtil.globFilesForDescriptions('multiple_files_*/*.spec.js', 'test/resources')
+    var expectedPaths = [
+      'multiple_files_one_description/first_test.spec.js',
+      'multiple_files_one_description/second_test.spec.js',
+      'multiple_files_multiple_descriptions/first_test.spec.js',
+      'multiple_files_multiple_descriptions/second_test.spec.js'
+    ]
+    var expected = {
+      'first test description': expectedPaths[0],
+      'second test description': expectedPaths[1],
+      'first test first description': expectedPaths[2],
+      'first test second description': expectedPaths[2],
+      'second test first description': expectedPaths[3],
+      'second test second description': expectedPaths[3]
+    }
+    expect(filesForDescriptions).toEqual(expected)
+  })
 })


### PR DESCRIPTION
This is one possible way to add test file paths relative to `basePath`, to make it consistent and not break backwards compatibility of `testPaths` and `testFilePattern`. Note that I'm not a fan of my new config item name (`basePathGlob`) but having trouble thinking of a better one. "testFilesGlobFromBasePath" is a bit cumbersome. Naming is hard. 

The gist is that config item `sonarQubeUnitReporter.basePathGlob` is a globbed file path, relative to `basePath`, that will override `testPaths` and `testFilePattern`. The path attribute that ends up in the outputFile xml is also relative to `basePath`.

Cheers!
