### PR TITLE
Ability to specify multiple file types in testFilePattern section. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,14 @@ module.exports = function(config) {
 
 By default, the description of the jasmine tests used as the path attribute in the generated xml. If this is not the case with your tests, you can use the following options to automagically find the right path values. It is the recommended way to use this plugin but to be backward compatible it is not enabled by default.
 
+`testFilePattern` can be specified as single pattern as `testFilePattern:'.spec.js'` or array of patterns `testFilePattern:  ['.spec.js', '.spec.ts']`.
 ```
 sonarQubeUnitReporter: {
       sonarQubeVersion: 'LATEST',
       outputFile: 'reports/ut_report.xml',
       overrideTestDescription: true,
       testPaths: ['./test', './moreTests'],
-      testFilePattern: '.spec.js',
+      testFilePattern:  ['.spec.js', '.spec.ts'],
       useBrowserName: false
 },
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-sonarqube-unit-reporter",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "A Karma plugin. Report results in sonar-unit-tests xml format.",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-sonarqube-unit-reporter",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "A Karma plugin. Report results in sonar-unit-tests xml format.",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tornaia/karma-sonarqube-unit-reporter.git"
+    "url": "https://github.com/swapnilfarande/karma-sonarqube-unit-reporter.git"
   },
   "keywords": [
     "junit",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-sonarqube-unit-reporter",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "A Karma plugin. Report results in sonar-unit-tests xml format.",
   "main": "index.js",
   "files": [

--- a/src/file-util.js
+++ b/src/file-util.js
@@ -59,7 +59,7 @@ function findFilesInDir (startPath, filter) {
       if (Array.isArray(filter)) {
         filter.forEach((f) => {
           if (filename.endsWith(f)) {
-            results.push(f)
+            results.push(filename)
           }
         })
       } else if (filename.endsWith(filter)) {

--- a/src/file-util.js
+++ b/src/file-util.js
@@ -58,8 +58,8 @@ function findFilesInDir (startPath, filter) {
     } else {
       if (Array.isArray(filter)) {
         filter.forEach((f) => {
-          if (filename.endsWith(filter)) {
-            results.push(filename)
+          if (filename.endsWith(f)) {
+            results.push(f)
           }
         })
       } else if (filename.endsWith(filter)) {

--- a/src/file-util.js
+++ b/src/file-util.js
@@ -55,9 +55,18 @@ function findFilesInDir (startPath, filter) {
       if (filename !== 'node_modules') {
         results = results.concat(findFilesInDir(filename, filter))
       }
-    } else if (filename.endsWith(filter)) {
-      results.push(filename)
+    } else {
+      if (Array.isArray(filter)) {
+        filter.forEach((f) => {
+          if (filename.endsWith(filter)) {
+            results.push(filename)
+          }
+        })
+      } else if (filename.endsWith(filter)) {
+        results.push(filename)
+      }
     }
   }
   return results
 }
+


### PR DESCRIPTION
Our current project has a requirement to have spec files in both `spec.js` and `spec.ts` format.  But current plugin doesn't have option to specify multiple file types and raising exceptions.

Now with this commit, `testFilePattern` can be specified as single pattern as `testFilePattern:'.spec.js'` or array of patterns `testFilePattern:  ['.spec.js', '.spec.ts']`.