### PR TITLE
Silent Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ module.exports = function(config) {
     files: listFiles(),
 
     singleRun: true,
-	
+
     colors:    false,
 
     autoWatch: false,
@@ -85,7 +85,8 @@ module.exports = function(config) {
     sonarQubeUnitReporter: {
       sonarQubeVersion: 'LATEST',
       outputFile: 'reports/ut_report.xml',
-      useBrowserName: false
+      useBrowserName: false,
+      silent: false
     },
 
     plugins: [
@@ -104,7 +105,7 @@ module.exports = function(config) {
     },
 
     reporters: ['progress', 'sonarqubeUnit', 'coverage'],
-    
+
     preprocessors: {
       'src/**/*.js':   ['coverage'],
       'test/**/*.js':   ['coverage']
@@ -124,7 +125,8 @@ sonarQubeUnitReporter: {
       overrideTestDescription: true,
       testPaths: ['./test', './moreTests'],
       testFilePattern: '.spec.js',
-      useBrowserName: false
+      useBrowserName: false,
+      silent: false
 },
 ```
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var SonarQubeUnitReporter = function(baseReporterDecorator, config, logger, help
   var outputDir = reporterConfig.outputDir
   var outputFile = reporterConfig.outputFile
   var useBrowserName = reporterConfig.useBrowserName
+  var silentMode = reporterConfig.silent;
 
   var filenameFormatter = reporterConfig.filenameFormatter || null
   var testnameFormatter = reporterConfig.testnameFormatter || null
@@ -212,7 +213,7 @@ var SonarQubeUnitReporter = function(baseReporterDecorator, config, logger, help
   var testPath = reporterConfig.testPath || './'
   var testPaths = reporterConfig.testPaths || [testPath]
   var testFilePattern = reporterConfig.testFilePattern || '(.spec.ts|.spec.js)'
-  var filesForDescriptions = fileUtil.getFilesForDescriptions(testPaths, testFilePattern)
+  var filesForDescriptions = fileUtil.getFilesForDescriptions(testPaths, testFilePattern, silentMode)
 
   function defaultFilenameFormatter(nextPath, result) {
     return filesForDescriptions[nextPath]

--- a/src/file-util.js
+++ b/src/file-util.js
@@ -5,7 +5,7 @@ module.exports = {
   getFilesForDescriptions: getFilesForDescriptions
 }
 
-function getFilesForDescriptions (startPaths, filter) {
+function getFilesForDescriptions (startPaths, filter, silentMode) {
   var ret = {}
 
   startPaths.forEach(function (startPathItem) {
@@ -34,7 +34,9 @@ function getFilesForDescriptions (startPaths, filter) {
           position = 0
           fileText = fileText.substring(descriptionEnd)
         }
-        console.log('-- describe: ' + describe + ' -> file: ' + item)
+        if (!silentMode) {
+          console.log('-- describe: ' + describe + ' -> file: ' + item)
+        }
       }
     } catch (e) {
       console.log('Error:', e.stack)


### PR DESCRIPTION
Adds a silent mode. When silentMode is true, it skips the logging when mapping describe blocks to filenames. 

SilentMode defaults to false so existing users should not see a change.