### PR TITLE
Add append formatter option

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,6 +209,7 @@ var SonarQubeUnitReporter = function(baseReporterDecorator, config, logger, help
 
   // look for jasmine test files in the specified path
   var overrideTestDescription = reporterConfig.overrideTestDescription || false
+  var addFilenameFormatter = reporterConfig.addFilenameFormatter || false
   var testPath = reporterConfig.testPath || './'
   var testPaths = reporterConfig.testPaths || [testPath]
   var testFilePattern = reporterConfig.testFilePattern || '(.spec.ts|.spec.js)'
@@ -217,9 +218,17 @@ var SonarQubeUnitReporter = function(baseReporterDecorator, config, logger, help
   function defaultFilenameFormatter(nextPath, result) {
     return filesForDescriptions[nextPath]
   }
-
+  
   if (overrideTestDescription) {
-    filenameFormatter = defaultFilenameFormatter
+    var currentFormatter = filenameFormatter
+    if (addFilenameFormatter && filenameFormatter !== null) {
+      if (addFilenameFormatter === 'append') {
+        filenameFormatter = (nextPath, result) => currentFormatter(defaultFilenameFormatter(nextPath, result), result)
+      }
+      // extend here for other options (such as 'prepend')
+    } else {
+      filenameFormatter = defaultFilenameFormatter
+    }
   }
 }
 


### PR DESCRIPTION
Add option to append a filenameFormatter. This could be extended in the future to accept a prepend option. I could not think of a use for prepend since it would modify the test name before the default formatter had a chance to modify it. Another acceptable solution would be to overload 'overrideTestDescription' with the option, but the meaning of 'append' vs 'prepend' was vague (does append mean that the override is before or after the custom formatter?)

Usage:
To append a formatter (i.e. let the default reporter convert to a filename and then modify the result of that) 
karma.conf.js:
```javascript
sonarQubeUnitReporter: {
  sonarQubeVersion: 'LATEST',
  overrideTestDescription: true,
// note that at the time of this writing, leaving testFilePattern unspecified results in a runtime exception
  testFilePattern: '.spec.ts',
  filenameFormatter: function(nextPath, result) {
    return 'customPathPrefix/' + nextPath
  },
  addFilenameFormatter: 'append'
}
```