### PR TITLE
Strip error logs from invalid characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var path = require('path')
 var fs = require('fs')
 var builder = require('xmlbuilder')
 var fileUtil = require('./src/file-util.js')
+var logTextUtil = require('./src/log-text-util.js')
 
 var SonarQubeUnitReporter = function(baseReporterDecorator, config, logger, helper, formatError) {
   var log = logger.create('reporter.sonarqubeUnit')
@@ -194,7 +195,7 @@ var SonarQubeUnitReporter = function(baseReporterDecorator, config, logger, help
     }
 
     if (!result.success) {
-      testCase.ele('failure', { message: 'Error' }, formatError(result.log.join('\n\n')))
+      testCase.ele('failure', { message: 'Error' }, formatError(logTestUtil.stripInvalidXmlCharacters(result.log.join('\n\n'))))
     }
   }
 

--- a/src/log-text-util.js
+++ b/src/log-text-util.js
@@ -1,0 +1,11 @@
+var path = require('path')
+var fs = require('fs')
+
+module.exports = {
+  stripInvalidXmlCharacters: stripInvalidXmlCharacters
+}
+
+function stripInvalidXmlCharacters(loggedText) {
+    return loggedText.replace(/[\0-\x08\x0B\f\x0E-\x1F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/g, '')
+}
+  


### PR DESCRIPTION
Colored fonts and backgrounds in logging reports are causing errors while creating the report XML.
This fix adds a function that uses the same regex that XMLBuilder checks for unexpected characters and strips the report log from them.