### PR TITLE
Fixes #24 Add prependTestFileName option for subdirectory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,12 @@ sonarQubeUnitReporter: {
 
 * npm install
 * npm build
+
+##### Additional Arguments
+
+```
+sonarQubeUnitReporter: {
+  prependTestFileName: 'frontend' # This adds a string to the front of the generated file name in the report
+                                  # Useful if you run tests from within a subdirectory
+}
+```

--- a/index.js
+++ b/index.js
@@ -211,11 +211,16 @@ var SonarQubeUnitReporter = function(baseReporterDecorator, config, logger, help
   var overrideTestDescription = reporterConfig.overrideTestDescription || false
   var testPath = reporterConfig.testPath || './'
   var testPaths = reporterConfig.testPaths || [testPath]
+  var prependTestFileName = reporterConfig.prependTestFileName || ''
   var testFilePattern = reporterConfig.testFilePattern || '(.spec.ts|.spec.js)'
   var filesForDescriptions = fileUtil.getFilesForDescriptions(testPaths, testFilePattern)
 
   function defaultFilenameFormatter(nextPath, result) {
-    return filesForDescriptions[nextPath]
+    if (prependTestFileName !== '') {
+      return prependTestFileName + '/' + filesForDescriptions[nextPath]
+    } else {
+      return filesForDescriptions[nextPath]
+    }
   }
 
   if (overrideTestDescription) {

--- a/src/file-util.js
+++ b/src/file-util.js
@@ -34,7 +34,6 @@ function getFilesForDescriptions (startPaths, filter) {
           position = 0
           fileText = fileText.substring(descriptionEnd)
         }
-        console.log('-- describe: ' + describe + ' -> file: ' + item)
       }
     } catch (e) {
       console.log('Error:', e.stack)


### PR DESCRIPTION
Adds an extra option to allow prepending a string to the test file names that are generated.
Also removes the unnecessary console.log in file-util.js which spams output

Addresses issues in https://github.com/tornaia/karma-sonarqube-unit-reporter/issues/24 